### PR TITLE
Add Twitter share button after game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
           <p><span class="tag">Score</span><span id="score">0</span></p>
           <p><span class="tag">Record</span><span id="best">0</span></p>
         </div>
-        <button id="start">Démarrer</button>
+        <div class="actions">
+          <button id="start">Démarrer</button>
+          <button id="share" type="button">Partager mon score</button>
+        </div>
         <p class="hint">Espace • Clique • Toucher = battement d'ailes</p>
       </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('start');
+const shareBtn = document.getElementById('share');
 const scoreNode = document.getElementById('score');
 const bestNode = document.getElementById('best');
 
@@ -39,6 +40,14 @@ const particles = [];
 
 bestNode.textContent = bestScore;
 
+function hideShareButton() {
+  shareBtn.style.display = 'none';
+}
+
+function showShareButton() {
+  shareBtn.style.display = 'block';
+}
+
 function resize() {
   const cssWidth = canvas.clientWidth || 640;
   const cssHeight = canvas.clientHeight || 480;
@@ -64,6 +73,7 @@ function resetGame() {
   bird.rotation = 0;
   spawnTimer = 0;
   pulse = 0;
+  hideShareButton();
 }
 
 function startGame() {
@@ -80,6 +90,7 @@ function endGame() {
     bestNode.textContent = bestScore;
     localStorage.setItem('flappy-dopamine-best', bestScore);
   }
+  showShareButton();
 }
 
 function flap() {
@@ -348,6 +359,21 @@ document.addEventListener('keydown', (event) => {
 canvas.addEventListener('pointerdown', handlePress);
 canvas.addEventListener('touchstart', handlePress, { passive: false });
 startBtn.addEventListener('click', handlePress);
+
+shareBtn.addEventListener('click', () => {
+  if (state !== STATE_GAMEOVER) {
+    return;
+  }
+  const pointsLabel = score > 1 ? 'points' : 'point';
+  const tweetText = `Je viens de marquer ${score} ${pointsLabel} sur Flappy Dopamine ! Viens planer avec moi ✨`;
+  const tweetUrl = new URL('https://twitter.com/intent/tweet');
+  tweetUrl.searchParams.set('text', tweetText);
+  tweetUrl.searchParams.set('hashtags', 'FlappyDopamine');
+  if (window.location.protocol.startsWith('http')) {
+    tweetUrl.searchParams.set('url', window.location.href);
+  }
+  window.open(tweetUrl.toString(), '_blank', 'noopener');
+});
 
 resize();
 resetGame();

--- a/style.css
+++ b/style.css
@@ -86,6 +86,16 @@ h1 {
   margin-bottom: 0.35rem;
 }
 
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.actions button {
+  width: 100%;
+}
+
 #score,
 #best {
   font-size: 2.2rem;
@@ -110,6 +120,16 @@ button {
 button:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow: 0 1.6rem 3rem rgba(0, 255, 213, 0.35);
+}
+
+#share {
+  display: none;
+  background: linear-gradient(135deg, var(--secondary), var(--accent));
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 255, 213, 0.25);
+}
+
+#share:hover {
+  box-shadow: 0 1.6rem 3rem rgba(255, 213, 0, 0.35);
 }
 
 .hint {


### PR DESCRIPTION
## Summary
- add a share action beside the start control in the sidebar
- toggle the button visibility based on the game state and prefill a Twitter intent with the last score
- style the new button to match the existing UI aesthetics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d3e20885d08327864e4e5b563752b1